### PR TITLE
Typos, moons, btc node container

### DIFF
--- a/content/guides/running-a-galaxy.md
+++ b/content/guides/running-a-galaxy.md
@@ -115,7 +115,7 @@ with your children to elective services is an obvious step.
 
 Any services that might require a specialized dedicated host could be
 offered by a galaxy. Services like 
-[%btc-provider](https://github.com/urbit/urbit-bitcoin-rpc), WebRTC STUN/TURN, object hosting like S3, or operating a layer 2
+[%btc-provider](https://github.com/urbit/urbit-bitcoin-rpc) ([Docker image](https://hub.docker.com/r/wexpertsystems/urbit-bitcoin-node)), WebRTC STUN/TURN, object hosting like S3, or operating a layer 2
 roller are 
 potentially valuable for your residents and beyond. Neither stars nor
 galaxies have any specialized ability to deliver these out of the box --
@@ -174,7 +174,7 @@ have escaped to new sponsors -- and if so, why. Ask your seller about
 
 Galaxies rarely change hands, and are not usually listed publicly. If
 you are interested in purchasing a galaxy, your best bet is through
-solicition through word of mouth. A good place to start looking is in
+solicitation through word of mouth. A good place to start looking is in
 on-network groups like [The Marketplace](web+urbitgraph://group/~tirrel/the-marketplace),
 a public group where over-the-counter point sales are coordinated, or
 [Cryptocurrency Forum](web+urbitgraph://group/~sonwet/cryptocurrency-forum), a public group related to trading
@@ -255,7 +255,7 @@ To transfer an incoming galaxy to a master ticket:
 
 Take advantage of your [proxy
 addresses](https://urbit.org/docs/glossary/proxies) to
-delegatevoting, spawning, and management privileges to different
+delegate voting, spawning, and management privileges to different
 addresses than your ownership key (see '[Key management](#key-management)' section below). Urbit's [HD wallet](https://urbit.org/docs/azimuth/azimuth%23the-urbit-hd-wallet) design
 makes it easy to keep your ownership key locked in a box while you
 perform typical operations with subsidiary keys, or re-derive those keys
@@ -497,7 +497,7 @@ friendly.
 
 To **withdraw an unlocked star**:
 
--   Authenticate into Bridge with your ownership key.]{.c3}
+-   Authenticate into Bridge with your ownership key.
 -   Navigate to the 'Lockup Contract' menu.
 -   Under 'Locked', you can see the number of stars available to
     withdraw from lockup. Here you can specify the ETH address you want
@@ -601,7 +601,7 @@ the hash of the text manually, which you can do easily with an
 [online](https://emn178.github.io/online-tools/keccak_256.html) [generator](https://keccak-256.cloxy.net/).
 
 Compare the output to the hash of the proposal in Bridge and make sure
-they are identical.]{.c3}
+they are identical.
 
 For upgrade proposals, the Bridge menu entry will contain the address
 of a modified contract on the Ethereum blockchain.

--- a/content/guides/running-a-star.md
+++ b/content/guides/running-a-star.md
@@ -143,7 +143,7 @@ them.
 As a star, you are a natural Schelling point to provide services for
 the planets you spawn. The following services are all elective, but act
 as examples of useful services for your customers and residents.
-Services might be offered gratis or as a commercial service.
+Services might be offered gratis or as a commercial service. Services that run on Urbit ships should be delegated to moons so that they don't slow down the core services your star provides.
 
 ### Bitcoin
 
@@ -158,20 +158,24 @@ choice.
 
 In order to facilitate Bitcoin transactions, you need to run a full node
 with a specific configuration and [software
-stack](https://github.com/urbit/urbit-bitcoin-rpc).
+stack](https://github.com/urbit/urbit-bitcoin-rpc). You can use a [Docker
+Container](https://hub.docker.com/r/wexpertsystems/urbit-bitcoin-node) to
+simplify deployment and scaling. 
+
 Once your blockchain is synced and the stack is ready to go, you'll
 connect the `%btc-provider` app to your full node, then whitelist
 any clients or groups that you want to allow access: 
 
 ```
-dojo> :btc-provider|command add-whitelist+[%users (silt ~[~sampel-palnet])]
-dojo> :btc-provider|command add-whitelist+[%groups (silt [~sampel %group-name]~)
-dojo> :btc-provider|command [%add-whitelist %kids ~]
+dojo> :btc-provider +bitcoin!btc-provider/command [%add-whitelist %kids ~]
+dojo> :btc-provider +bitcoin!btc-provider/command [%add-whitelist [%groups groups=(sy ~[[~sampel %group-name]])]]
+dojo> :btc-provider +bitcoin!btc-provider/command [%add-whitelist [%users users=(sy ~[~wallet-hodler])]]
+dojo> :btc-provider +bitcoin!btc-provider/command [%add-whitelist %public ~]
 ```
 
 Note that running `%btc-provider` and a full node on the same
 machine as your star may prove burdensome, so it may make sense for you
-to delegate it to another machine, or to run `%btc-provider` on a
+to delegate it to another machine, as well as running `%btc-provider` on a
 moon.
 
 ### Rollers


### PR DESCRIPTION
- Found a couple of typos that escaped me in cleanup
- Placed emphasis on the use of moons for services; this should be default advice since ship speed is usually the main performance bottleneck
- Linked to new %btc-provider full node Docker container + tutorial that ~wex & I put together from ~timluc-miptev's original repo 