### PR TITLE
adds `.` (jamfile command) to dojo docs

### DIFF
--- a/content/manual/os/dojo-tools.md
+++ b/content/manual/os/dojo-tools.md
@@ -759,6 +759,13 @@ usage = "Dojo"
 slug = "#trim"
 desc = "Dojo utility included in the %base desk."
 
+[glossaryEntry."Make a jamfile and write to disk"]
+name = "Make a jamfile and write to disk"
+symbol = "."
+usage = "Dojo"
+slug = "#."
+desc = "Dojo utility included in dojo.hoon"
+
 +++
 
 [path]: https://developers.urbit.org/reference/glossary/path
@@ -1597,13 +1604,13 @@ These tools are mostly useful to developers or similarly technical people.
 
 ### `.`
 
-Noun to jamfile. The noun is given to `+jam` and then written to
-`pier/.urb/put/filename.ext` using a `%sag` `%blit`, saving it as a jamfile.
+Make a jamfile and write to disk. A noun is jammed and then written to
+`pier/.urb/put/path/extension` using a `%sag` `%blit`, saving it as a jamfile.
 
 #### Arguments
 
 ```
-path noun
+path/extension noun
 ```
 
 #### Example

--- a/content/manual/os/dojo-tools.md
+++ b/content/manual/os/dojo-tools.md
@@ -1595,6 +1595,41 @@ Disconnect from a remote dojo session:
 
 These tools are mostly useful to developers or similarly technical people.
 
+### `.`
+
+Noun to jamfile. The noun is given to `+jam` and then written to
+`pier/.urb/put/filename.ext` using a `%sag` `%blit`, saving it as a jamfile.
+
+#### Arguments
+
+```
+path noun
+```
+
+#### Example
+
+This command is often used for writing pills to disk - see e.g.
+[`+solid`](#solid).
+
+```
+> .solid/pill +solid %base
+```
+
+You can also jam arbitrary nouns, e.g.
+
+```
+> .decrement/atom [8 [1 0] 8 [1 6 [5 [0 7] 4 0 6] [0 6] 9 2 [0 2] [4 0 6] 0 7] 9 2 0 1]
+```
+
+This is the Nock formula for decrement. If you copy it from
+`/pier/.urb/put/decrement.atom` to `pier/base` then you can run it by
+scrying it from Clay and running `+cue` to reobtain the formula. 
+
+```
+> .*(100 (cue .^(@ %cx %/decrement/atom)))
+99
+```
+
 ### `+ames-flows`
 
 Print details of [Ames][ames] flows by ship.


### PR DESCRIPTION
Hope that `.` doesn't trip up Markdown. I don't know what else to call it, but I couldn't find it documented anywhere.