### PR TITLE
dojo-tools: remove references to nonexistent |resume

### DIFF
--- a/content/manual/os/dojo-tools.md
+++ b/content/manual/os/dojo-tools.md
@@ -52,13 +52,6 @@ usage = "Dojo"
 slug = "#rein"
 desc = "Dojo utility included in the %base desk."
 
-[glossaryEntry."Resume updates on a desk"]
-name = "Resume updates on a desk"
-symbol = "|resume"
-usage = "Dojo"
-slug = "#resume"
-desc = "Dojo utility included in the %base desk."
-
 [glossaryEntry."Revive all agents on a desk, migrating archived states"]
 name = "Revive all agents on a desk, migrating archived states"
 symbol = "|revive"
@@ -815,7 +808,7 @@ organized into rough categories for convenience.
 ## Apps and updates
 
 These tools are for managing [desks][desk], apps and updates. Install,
-uninstall, suspend, resume, pause updates, etc.
+uninstall, suspend, pause updates, etc.
 
 ### `+agents`
 
@@ -1032,27 +1025,6 @@ Revive a desk:
 
 ```
 |rein %bitcoin
-```
-
----
-
-### `|resume`
-
-Resume updates on a desk.
-
-Start tracking previously [`|pause`](#pause)d updates from a desk's upstream
-source.
-
-#### Arguments
-
-```
-desk
-```
-
-#### Examples
-
-```
-|resume %bitcoin
 ```
 
 ---


### PR DESCRIPTION
`|resume` [was removed](https://github.com/urbit/urbit/commit/fa569cf7f3411925c45cbfff65cb2a049c115d57#diff-906d7d50f56743b21b8685c029675312ca28d871cb0eba3e00aa795dab7378b4L460) as a part of the agents in clay work.