### PR TITLE
s3: update DigitalOcean instructions

### DIFF
--- a/content/manual/os/s3.md
+++ b/content/manual/os/s3.md
@@ -12,7 +12,7 @@ To enable S3 support on your ship you'll need to first set up a bucket, and then
 
 ### Bucket Setup
 
-We recommend DigitalOcean's Spaces, but any s3 provider that supports signature v2 should work. 
+We recommend DigitalOcean's Spaces, but any S3 provider that supports signature v2 should work. 
 
 The bucket has to be publicly readable, allow CORS from `*` origins, allow GET and PUT methods, and allow `*` headers. Specific instructions for DigitalOcean are below.
 
@@ -31,7 +31,7 @@ Once you've created your space you'll want to navigate to its settings in Digita
 Then you'll want to set the CORS Configurations as specified above, this should look like the following image (your endpoint will vary depending upon region).
 ![digital-ocean-settings](https://media.urbit.org/site/using/os/digital-ocean-settings.png)
 ![digital-ocean-cors-settings](https://media.urbit.org/site/using/os/digital-ocean-cors-settings.png)
-Finally you'll need to create an API key so you can configure your ship to have access to your newly created s3 bucket.
+Finally you'll need to create an API key so you can configure your ship to have access to your newly created S3 bucket.
 
 Click API in the bottom left of the DigitalOcean navigation bar on the left side of the webpage.
 
@@ -47,28 +47,17 @@ The Endpoint depends on the region you selected, but can be found in the setting
 
 The Access Key ID and Secret Access Key are from the API key we just generated. Put each one in the correct field and save.
 
-The Bucket Name is the name of your digital ocean space. Once you've added that you'll also need to click "Save" at the bottom of the form.
+The Bucket Name is the name of your DigitalOcean Space. 
 
-Once all of that's complete you should be good to go! Test that things are working by attempting to attach or send and image via chat. It should work. You can manage your images by logging into Digital Ocean and looking at the folder in your newly created space. You can use your same space for multiple urbit IDs by creating new API keys. Each ID will create a new directory within that space using its name by default.
+The Region should be `global`. This is the default for DigitalOcean, which has no awareness of regionality through their S3 API.
+
+Once you've added that you'll also need to click "Save" at the bottom of the form.
+
+You should be good to go! Test that things are working by attempting to attach or send and image via chat. It should work. You can manage your images by logging into DigitalOcean and looking at the folder in your newly created space. You can use your same space for multiple urbit IDs by creating new API keys. Each ID will create a new directory within that space using its name by default.
 
 To manage your S3 inventory on your urbit, install Silo: web+urbitgraph://~dister-nocsyx-lassul/silo (Warning: still in Beta)
 
-When uploading assets to your Digital Ocean space manually, ensure the assets are public, not private.
-
-### Add your credentials: Dojo
-
-Alternatively to the instructions above, you can run these dojo commands instead of updating system preferences. If you followed the instructions above you should *not* do this.
-
-```
-:s3-store|set-endpoint 'endpoint.mys3provider.com'
-:: AWS endpoint example: s3-us-west-2.amazonaws.com
-:: Digital Ocean endpoint example: sfo2.digitaloceanspaces.com
-:s3-store|set-access-key-id 'MYACCESSKEYID'
-:s3-store|set-secret-access-key 'MYSECRETACCESSKEY'
-:s3-store|set-current-bucket 'yourbucketname'
-```
-
-Done! If you need to peek at s3-store’s state, you can always run :s3-store +dbug (inside Dojo, not web Dojo, unfortunately). You’ll see the additional functionality appear in Groups and Chat.
+When uploading assets to your DigitalOcean space manually, ensure the assets are public, not private.
 
 ### Hosting your own S3 solution (Advanced)
 


### PR DESCRIPTION
Landscape needs a "region" parameter, which is `global` for all of DigitalOcean.

`s3-store` is also deprecated.